### PR TITLE
Added support for Kelvin scale.

### DIFF
--- a/package/contents/code/temperature-utils.js
+++ b/package/contents/code/temperature-utils.js
@@ -2,10 +2,17 @@ function toFahrenheit(celsia) {
     return celsia * (9/5) + 32
 }
 
+function toKelvin(celsia) {
+    return celsia + 273.15
+}
+
 function getTemperature(celsiaDouble, fahrenheitEnabled) {
     var fl = celsiaDouble
-    if (fahrenheitEnabled) {
-        fl = toFahrenheit(fl)
+    if (temperatureUnit == "°F") {
+	fl = toFahrenheit(fl)
+    }
+    else if (temperatureUnit == "K") {
+	fl = toKelvin(fl)
     }
     return Math.round(fl)
 }

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -42,9 +42,9 @@
         <entry name="updateInterval" type="Double">
             <default>3.0</default>
         </entry>
-        <entry name="fahrenheitEnabled" type="Bool">
-            <default>false</default>
-        </entry>
+	<entry name="temperatureUnit" type="String">
+	  <default>°C</default>
+	</entry>
     </group>
     
 </kcfg>

--- a/package/contents/ui/TemperatureItem.qml
+++ b/package/contents/ui/TemperatureItem.qml
@@ -77,7 +77,16 @@ Item {
             verticalAlignment: Text.AlignBottom
             
             opacity: isOff ? 0.7 : 1
-            text: isOff ? i18n('OFF') : TemperatureUtils.getTemperature(temperature, fahrenheitEnabled) + '°'
+
+            text: {
+                if (isOff)
+                    return i18n('OFF')
+                else if (temperatureUnit == "K")
+                    return TemperatureUtils.getTemperature(temperature, temperatureUnit)
+                else
+                    return TemperatureUtils.getTemperature(temperature, temperatureUnit) + '°'
+            }
+
         }
     }
     

--- a/package/contents/ui/config/ConfigMisc.qml
+++ b/package/contents/ui/config/ConfigMisc.qml
@@ -6,18 +6,24 @@ Item {
     
     property alias cfg_updateInterval: updateIntervalSpinBox.value
     
-    property bool cfg_fahrenheitEnabled
+    property string cfg_temperatureUnit
 
-    onCfg_fahrenheitEnabledChanged: {
-        if (cfg_fahrenheitEnabled) {
-            temperatureTypeGroup.current = temperatureFahrenheit
-        } else {
+    onCfg_temperatureUnitChanged: {
+
+        if (cfg_temperatureUnit == "°C") {
             temperatureTypeGroup.current = temperatureCelsius
         }
+        else if (cfg_temperatureUnit == "°F") {
+            temperatureTypeGroup.current = temperatureFahrenheit
+        }
+        else {
+            temperatureTypeGroup.current = temperatureKelvin
+        }
     }
-    
+
+
     Component.onCompleted: {
-        cfg_fahrenheitEnabledChanged()
+        cfg_temperatureUnitChanged()
     }
     
     ExclusiveGroup {
@@ -54,7 +60,7 @@ Item {
             id: temperatureCelsius
             exclusiveGroup: temperatureTypeGroup
             text: i18n("°C")
-            onCheckedChanged: if (checked) cfg_fahrenheitEnabled = false
+            onCheckedChanged: if (checked) cfg_temperatureUnit = "°C"
         }
         Item {
             width: 2
@@ -65,9 +71,20 @@ Item {
             id: temperatureFahrenheit
             exclusiveGroup: temperatureTypeGroup
             text: i18n("°F")
-            onCheckedChanged: if (checked) cfg_fahrenheitEnabled = true
+            onCheckedChanged: if (checked) cfg_temperatureUnit = "°F"
+        }
+	Item {
+            width: 2
+            height: 2
+            Layout.rowSpan: 1
+        }
+        RadioButton {
+            id: temperatureKelvin
+            exclusiveGroup: temperatureTypeGroup
+            text: i18n("K")
+            onCheckedChanged: if (checked) cfg_temperatureUnit = "K"
         }
 
     }
-    
+
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -33,7 +33,7 @@ Item {
     property bool initialized: false
     
     // configuration
-    property bool fahrenheitEnabled: plasmoid.configuration.fahrenheitEnabled
+    property string temperatureUnit: plasmoid.configuration.temperatureUnit
     property string configuredResources: plasmoid.configuration.resources
     property int baseWarningTemperature: plasmoid.configuration.warningTemperature
     property int baseMeltdownTemperature: plasmoid.configuration.meltdownTemperature


### PR DESCRIPTION
Hello,

I wanted to see the temperature of my CPU Cores in Kelvin and since this widget didn't support this functionality, I added it. Apart from my personnel preference, I think the Kelvin scale should be added simply because it is the SI unit of the temperature and thusly the 'most correct' unit.

Adding support for more than two temperature units required changes to the way the switching of the unit is handled. Until now there existed a boolean variable 'fahrenheitEnabled' which decided which unit to use. For more than two units this approach fails. As a replacement for 'fahrenheitEnabled' I created the variable 'temperatureUnit', which stores the unit as a string, and adjusted every function to work with 'temperatureUnit' rather than 'fahrenheitEnabled'. This allows for an arbitrarily high number of units which can be introduced now. 

Additionally I created the function 'toKelvin(celsia)' to calculate the value in Kelvin from the Celsius value. This is slightly redundant to the function 'toCelsia(kelvin)' which does the opposite, but since it is explicitly stated that Celsius shall be the default scale, I didn't changed that.

Last but not least, I made the appearance of the degree sign '°' dependent on the used temperature unit. For Celsius and Fahrenheit it is displayed, for Kelvin not.

I tested these changes on a machine with Debian Stretch and KDE installed and it works just fine.