### PR TITLE
Set maximum of individual temperature

### DIFF
--- a/package/contents/ui/config/ConfigTemperatures.qml
+++ b/package/contents/ui/config/ConfigTemperatures.qml
@@ -325,6 +325,7 @@ Item {
                 id: warningTemperatureItem
                 stepSize: 10
                 minimumValue: 10
+                maximumValue: 200
                 enabled: overrideLimitTemperatures.checked
             }
             
@@ -336,6 +337,7 @@ Item {
                 id: meltdownTemperatureItem
                 stepSize: 10
                 minimumValue: 10
+                maximumValue: 200
                 enabled: overrideLimitTemperatures.checked
             }
             


### PR DESCRIPTION
Set this to the value of maximum global temperature.

Without this patch I can't input more than 99 in individual temperature field.