### PR TITLE
Fixing unusable source selection UI on systems with many sources #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,13 @@ or
 $ sudo rm -r /usr/share/plasma/plasmoids/org.kde.thermalMonitor
 $ sudo rm /usr/share/kservices5/plasma-applet-org.kde.thermalMonitor.desktop
 ```
+
+### DEV DEPENDENCIES
+
+In Arch Linux:
+```sh
+sudo pacman -S kde-development-environment-meta
+```
+
 ### LICENSE
 This project is licensed under the [GNU General Public License v2.0](https://www.gnu.org/licenses/gpl-2.0.html) and is therefore Free Software. A copy of the license can be found in the [LICENSE file](LICENSE).

--- a/package/contents/ui/config/ConfigTemperatures.qml
+++ b/package/contents/ui/config/ConfigTemperatures.qml
@@ -10,6 +10,7 @@ Item {
     id: resourcesConfigPage
     
     property double tableWidth: parent.width
+    property double tableHeight: parent.height
 
     property string cfg_resources
     property alias cfg_warningTemperature: warningTemperatureSpinBox.value
@@ -271,7 +272,7 @@ Item {
                 }
                 enabled: addResourceDialog.virtualSelected
                 Layout.preferredWidth: tableWidth/2
-                Layout.preferredHeight: contentHeight
+                Layout.preferredHeight: tableHeight/2
             }
             
             Item {


### PR DESCRIPTION
Just a quick fix for source selection UI on systems with many sources, as reported here: https://github.com/kotelnik/plasma-applet-thermal-monitor/issues/59.

I also added a quick reference for development dependencies to the README.

Please let me know if it's fine or there is something else I can do.