### PR TITLE
fix: use same gui settings for both global and per-sensor temperature limits

### DIFF
--- a/package/contents/ui/config/ConfigTemperatures.qml
+++ b/package/contents/ui/config/ConfigTemperatures.qml
@@ -323,8 +323,9 @@ Item {
             }
             SpinBox {
                 id: warningTemperatureItem
-                stepSize: 10
+                stepSize: 1
                 minimumValue: 10
+                maximumValue: 200
                 enabled: overrideLimitTemperatures.checked
             }
             
@@ -334,8 +335,9 @@ Item {
             }
             SpinBox {
                 id: meltdownTemperatureItem
-                stepSize: 10
+                stepSize: 1
                 minimumValue: 10
+                maximumValue: 200
                 enabled: overrideLimitTemperatures.checked
             }
             


### PR DESCRIPTION
See #74.

This should fix the issue for per-sensor settings, since different gui limits were used.