### PR TITLE
added note for ksysguard dependency

### DIFF
--- a/package/contents/ui/config/ConfigTemperatures.qml
+++ b/package/contents/ui/config/ConfigTemperatures.qml
@@ -356,6 +356,11 @@ Item {
             font.bold: true
             Layout.alignment: Qt.AlignLeft
         }
+         
+        Label {
+            text: i18n('You need ksysguard to show resources.')
+            Layout.alignment: Qt.AlignLeft
+        }
         
         Item {
             width: 2


### PR DESCRIPTION
I just read one comment on the KDE store, without it I would have thought this extension is broken.

Without ksysguard it doesnt work, on Kubuntu, Fedora, Fedora Kinoite, KDE Neon, all I tried dont have it preinstalled.